### PR TITLE
chore(TPR-3): Lock compiler version

### DIFF
--- a/contracts/registries/ThirdPartyRegistry.sol
+++ b/contracts/registries/ThirdPartyRegistry.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity  ^0.7.3;
+pragma solidity  0.7.6;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";


### PR DESCRIPTION
Fix compiler version to `0.7.6` (Not fixing on `0.7.3` because some dependencies have `0.7.6` as minimum)